### PR TITLE
fix(build): load NPM_REGISTRY from config

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -33,7 +33,7 @@ RUN git config --global user.email "tutor@overhang.io" \
   && git config --global user.name "Tutor"
 
 # nodejs requirements (aka: "make requirements.js")
-ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG NPM_REGISTRY={{ NPM_REGISTRY }}
 RUN npm install --verbose --registry=$NPM_REGISTRY
 RUN ./node_modules/.bin/bower install --allow-root
 


### PR DESCRIPTION
Edited ecommerce's Dockerfile to replace the official npm registry URL in with the `NPM_REGISTRY` config defaulting to the same value.
- The same is done across all tutor repositories.
- No need to rebuild image for default configuration